### PR TITLE
Updated modules based on feedback

### DIFF
--- a/content/10-regulatory-compliance/1-kube-bench/Lab3/index.en.md
+++ b/content/10-regulatory-compliance/1-kube-bench/Lab3/index.en.md
@@ -61,7 +61,7 @@ spec:
       hostPID: true
       containers:
         - name: kube-bench
-          image: docker.io/aquasec/kube-bench:latest
+          image: docker.io/aquasec/kube-bench:v0.6.19
           command:
             [
               "kube-bench",

--- a/content/2-identity-and-access-management/1-iam-groups-roles-to-manage-eks-access/7-test-eks-access/index.en.md
+++ b/content/2-identity-and-access-management/1-iam-groups-roles-to-manage-eks-access/7-test-eks-access/index.en.md
@@ -3,7 +3,6 @@ title : "Test Amazon EKS access"
 weight : 27
 ---
 
-
 ## Automate assumerole with aws cli
 
 
@@ -15,7 +14,13 @@ It is possible to automate the retrieval of temporary credentials for the assume
 mkdir -p ~/.aws
 
 if ! test -f ~/.aws/config; then
+touch ~/.aws/config
+else
+  echo "AWS Config file ~/.aws/config already exists..."
+fi
+
 cat << EoF >> ~/.aws/config
+
 [profile admin]
 role_arn=arn:aws:iam::${ACCOUNT_ID}:role/k8sAdmin
 source_profile=eksAdmin
@@ -29,9 +34,6 @@ role_arn=arn:aws:iam::${ACCOUNT_ID}:role/k8sInteg
 source_profile=eksInteg
 
 EoF
-else
-  echo "AWS Config file ~/.aws/config already exists..."
-fi
 ```
 
 #### Add in `~/.aws/credentials`:
@@ -97,6 +99,13 @@ The output looks like below.
 > When specifying the **\--profile admin** parameter we automatically ask for temporary credentials for the role k8sAdmin
 
 ## Using AWS profiles with the Kubectl config file
+
+### Install yq for yaml processing
+```bash
+echo 'yq() {
+  docker run --rm -i -v "${PWD}":/workdir mikefarah/yq "$@"
+}' | tee -a ~/.bashrc && source ~/.bashrc
+```
 
 It is also possible to specify the AWS\_PROFILE to use with the aws-iam-authenticator in the `~/.kube/config` file, so that it will use the appropriate profile.
 

--- a/content/2-identity-and-access-management/1-iam-groups-roles-to-manage-eks-access/index.en.md
+++ b/content/2-identity-and-access-management/1-iam-groups-roles-to-manage-eks-access/index.en.md
@@ -37,7 +37,7 @@ eksworkshop-admin
 
 ::::expand{header="Check Output if you running at AWS Event"}
 ```bash
-eks-bootstrap-template-ws-Cloud9InstanceRole-V1RKIVUA1ZM0
+eks-security-workshop
 ```
 ::::
 

--- a/content/2-identity-and-access-management/3-eks-pod-identity/1.eks-pod-identity-config/index.en.md
+++ b/content/2-identity-and-access-management/3-eks-pod-identity/1.eks-pod-identity-config/index.en.md
@@ -210,6 +210,7 @@ Look at the trust policy.
 ### Step2: Add Amazon EKS Pod Identity Agent add-on
 
 ```bash
+export EKS_CLUSTER_NAME="eksworkshop-eksctl"
 export EKS_POD_IDENTITY_ADDON_NAME="eks-pod-identity-agent"
 aws eks create-addon --cluster-name $EKS_CLUSTER_NAME --addon-name $EKS_POD_IDENTITY_ADDON_NAME
 ```

--- a/content/2-identity-and-access-management/3-eks-pod-identity/3.eks-pod-identity-deep-dive/index.en.md
+++ b/content/2-identity-and-access-management/3-eks-pod-identity/3.eks-pod-identity-deep-dive/index.en.md
@@ -11,7 +11,7 @@ In this section, let's deep dive into EKS Pod Identity and understand what is ha
 
 In the previous section, we created an IAM Role `eks-pod-s3-read-access-role` and called an API `create-pod-identity-association` to create an association between the IAM role and kubernetes service account `sa1` in the Namespace `ns-a`.
 
-When Amazon EKS starts a new pod that uses a service account with an EKS Pod Identity association, the [EKS Pod Identity webhook](https://github.com/aws/amazon-eks-pod-identity-webhookhttps://github.com/aws/amazon-eks-pod-identity-webhook) mutates the pod spec by adding two environment variables `AWS_CONTAINER_CREDENTIALS_FULL_URI` and `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE`.
+When Amazon EKS starts a new pod that uses a service account with an EKS Pod Identity association, the [EKS Pod Identity webhook](https://github.com/aws/amazon-eks-pod-identity-webhook) mutates the pod spec by adding two environment variables `AWS_CONTAINER_CREDENTIALS_FULL_URI` and `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE`.
 
  This is because EKS Pod Identities have been added to the [`Container credential provider`](https://docs.aws.amazon.com/sdkref/latest/guide/feature-container-credentials.html) which is searched by AWS SDKs in a step in the default credential chain.
  

--- a/content/introduction/index.en.md
+++ b/content/introduction/index.en.md
@@ -39,6 +39,12 @@ As part of this workshop we will cover the following modules:
 | **Detective Controls** | [Amazon GuardDuty Protection for EKS - Audit Log Monitoring](/5-detective-controls/1-guardDuty-protection-for-eks/eks-audit-logs) | 45 mins | N/A |
 | | [Amazon GuardDuty Protection for EKS - Runtime Monitoring](/5-detective-controls/1-guardDuty-protection-for-eks/eks-runtime) | 45 mins | N/A |
 | | [Analyze Amazon EKS Control Plane logs and Audit CloudTrail logs](/5-detective-controls/2-analyze-controlplane-cloudtrail-logs) | 60 mins | N/A |
+| **Network Security** | [Implementing Kubernetes Network Policies using Amazon VPC CNI](/6-network-security/1-network-policies) | 45 mins | N/A |
+| | [Implementing IAM Auth, TLS, Custom Domains and Multi Cluster Connectivity with Amazon VPC Lattice](/6-network-security/2-vpc-lattice-service-access) | 60 mins | N/A |
+| | [Enabling mTLS with ALB in Amazon EKS](/6-network-security/3-mtls-with-alb) | 45 mins | N/A |
+| | [Fully Private EKS Cluster](/6-network-security/4-fully-private-cluster) | 45 mins | N/A |
+| **Infrastructure Security** | [Bottlerocket Security Features on Amazon EKS](/8-infrastructure-security/1-bottlerocket-security-features-amazon-eks) | 45 mins | N/A |
+| | [Using Enclaves with Amazon EKS](/8-infrastructure-security/2-using-enclaves) | 30 mins | N/A |
 | **Regulatory Compliance**| [Building Amazon Linux 2 CIS Benchmark AMIs for Amazon EKS](/10-regulatory-compliance/cis-al2-eks/) | 60 mins | N/A |
 || [Validating Amazon EKS optimized Bottlerocket AMI against the CIS Benchmark](/10-regulatory-compliance/cis-bottlerocket-eks/) | 60 mins | N/A |
 |  | [CIS EKS Benchmark Assessment Using Kube-bench](/10-regulatory-compliance/kube-bench/) | 45 mins | N/A |


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
**Introduction**
- Updated the Introduction module to include Network Security and Infrastructure Security modules' details

**Identity and Access Management**
- Updated the output value of `Check Output if you running at AWS Event` in `Using AWS IAM Groups and Roles to Manage Kubernetes Cluster Access` mdule
- Updated the commands under `Add in ~/.aws/config` section in `Using AWS IAM Groups and Roles to Manage Kubernetes Cluster Access` module
- Added installation command for `yq` in `Using AWS IAM Groups and Roles to Manage Kubernetes Cluster Access` module
- Added export command for $EKS_CLUSTER_NAME in `Enable EKS Pod Identity` module
- Updated the `EKS Pod Identity webhook` link in `Deep Dive into EKS Pod Identity` module 


**Regulatory Compliance**
- Updated the aqua docker image to `docker.io/aquasec/kube-bench:v0.6.19` in `Lab 3 - Kube-bench Integration with AWS Security Hub` module as the container image `docker.io/aquasec/kube-bench:latest` has an [open issue](https://github.com/aquasecurity/kube-bench/issues/1595)
 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
