### PR TITLE
fix(security): enforce HTTPS-only S3 access [improve-startup]

### DIFF
--- a/static/inspector-codepipeline.yaml
+++ b/static/inspector-codepipeline.yaml
@@ -54,6 +54,24 @@ Resources:
   CodePipelineArtifactBucket:
     Type: AWS::S3::Bucket
 
+  CodePipelineArtifactBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref CodePipelineArtifactBucket
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: DenyInsecureConnections
+            Effect: Deny
+            Principal: "*"
+            Action: s3:*
+            Resource:
+              - !GetAtt CodePipelineArtifactBucket.Arn
+              - !Join ["", [!GetAtt CodePipelineArtifactBucket.Arn, "/*"]]
+            Condition:
+              Bool:
+                aws:SecureTransport: false
+
   ContainerComponentsRepo:
     Type: AWS::CodeCommit::Repository
     Properties:
@@ -171,7 +189,8 @@ Resources:
             Principal: "*"
             Action: s3:*
             Resource:
-              !Join ["", [!GetAtt CodePipelineArtifactStoreBucket.Arn, "/*"]]
+              - !GetAtt CodePipelineArtifactStoreBucket.Arn
+              - !Join ["", [!GetAtt CodePipelineArtifactStoreBucket.Arn, "/*"]]
             Condition:
               Bool:
                 aws:SecureTransport: false


### PR DESCRIPTION
## Summary
- Cherry-pick of S3 secure-transport fix (commit fc813bd from PR #58) to clear ACAT finding acat-cfnlint.EA013
- Adds HTTPS-only deny policy to `CodePipelineArtifactBucket` (previously had no policy)
- Extends existing `DenyInsecureConnections` on `CodePipelineArtifactStoreBucketPolicy` to cover both bucket and object ARNs

## Ticket
Resolves V2268145424 — "S3 bucket policy allows non-secure transport"

## Test plan
- cfn-lint passes (zero E-level errors, zero EA013 findings)
- No behavioral change to workshop — additive Deny statements only